### PR TITLE
Revert "PRE-4 Add oninput support"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predictive-textarea",
-  "version": "0.3.0",
+  "version": "0.2.6",
   "description": "A rich text input with AI-powered autocomplete content predictions for React",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/components/predictive-textarea.tsx
+++ b/src/components/predictive-textarea.tsx
@@ -40,7 +40,6 @@ function PredictiveTextarea({
   rows = 1,
   className,
   predictionClassName,
-  onInput,
   ...props
 }: PredictiveTextareaProps): React.ReactElement {
   const textareaRef = useRef<HTMLDivElement>(null)
@@ -75,11 +74,6 @@ function PredictiveTextarea({
     }
     else {
       clearPrediction()
-    }
-
-    // Call onInput with a textarea-like event shape
-    if (typeof onInput === 'function') {
-      onInput({ target: { value: newContent } } as { target: { value: string } })
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the props for the PredictiveTextarea component.
  */
-export interface PredictiveTextareaProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onInput'> {
+export interface PredictiveTextareaProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * A function that retrieves content predictions based on user input.
    * Usually, this will be some sort of API call to a language model.
@@ -54,11 +54,6 @@ export interface PredictiveTextareaProps extends Omit<React.HTMLAttributes<HTMLD
    * Use this to style the prediction text with your own classes.
    */
   predictionClassName?: string
-
-  /**
-   * A function that is called on all input events.
-   */
-  onInput?: (event: { target: { value: string } }) => void
 }
 
 /**

--- a/tests/components/predictive-textarea.test.tsx
+++ b/tests/components/predictive-textarea.test.tsx
@@ -84,12 +84,10 @@ describe('PredictiveTextarea', () => {
 
   it('should handle input changes', () => {
     mockIsAtLineEnd.mockReturnValue(false)
-    const mockOnInput = jest.fn()
 
     render(
       <PredictiveTextarea
         getContentPredictionFn={mockGetContentPredictionFn}
-        onInput={mockOnInput}
       />
     )
 
@@ -101,8 +99,7 @@ describe('PredictiveTextarea', () => {
     })
 
     expect(mockClearPrediction).toHaveBeenCalled()
-    expect(mockOnInput).toHaveBeenCalledWith({ target: { value: 'New text' } })
-    
+
     const hiddenInput = screen.getByDisplayValue('New text')
     expect(hiddenInput).toHaveValue('New text')
   })


### PR DESCRIPTION
Reverts JensAstrup/predictive-textarea#70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the custom input event callback from the predictive text area component.
  - Updated the predictive text area props to inherit standard input event handling.
- **Tests**
  - Adjusted tests to reflect the removal of the custom input event callback.
- **Chores**
  - Updated version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->